### PR TITLE
Fix mstlink core dump

### DIFF
--- a/mlxlink/modules/mlxlink_ui.cpp
+++ b/mlxlink/modules/mlxlink_ui.cpp
@@ -364,7 +364,7 @@ void MlxlinkUi::paramValidate()
 
 void MlxlinkUi::initCmdParser()
 {
-    for (u_int32_t it = SHOW_PDDR; it < FUNCTION_LAST; it++) {
+    for (u_int32_t it = SHOW_PDDR; it <= FUNCTION_LAST; it++) {
         _sendRegFuncMap.push_back(0);
     }
     AddOptions(DEVICE_FLAG, DEVICE_FLAG_SHORT, "MstDevice",


### PR DESCRIPTION
On Oracle Linux 8, mstlink is built with the hardening flag,
    -D_GLIBCXX_ASSERTIONS":
    
    $ rpm --eval %__global_compiler_flags
    -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2
    -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong
    -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1
    -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1
    
    When run, the commnads cores:
    
    /usr/include/c++/8/bits/stl_vector.h:932: std::vector<_Tp, _Alloc>::reference
    std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type)
    [with _Tp = unsigned int; _Alloc = std::allocator<unsigned int>;
    std::vector<_Tp, _Alloc>::reference = unsigned int&; std::vector<_Tp,
    _Alloc>::size_type = long unsigned int]: Assertion '__builtin_expect(__n <
    this->size(), true)' failed.
    Aborted (core dumped)
    
    MlxlinkUi::initCmdParser() initializes the _sendRegFuncMap vector. It pushes
    21 zeros to the vector:
    
        for (u_int32_t it = SHOW_PDDR; it < FUNCTION_LAST; it++) {
                _sendRegFuncMap.push_back(0);
        }
    
    SHOW_PDDR has a value of 1 and FUNCTION_LAST a value of 22.
    So the vector has a size of 21 entries.
    
    The core occurs at line at mlxlink_ui.cpp:305:
    
        if (_sendRegFuncMap[SEND_PEPC] == SEND_PEPC) {
    
    SEND_PEPC has a value of 21:
    
        enum SHOW_FUNCTIONS {
                SHOW_PDDR = 1,
                SHOW_PCIE,
                SHOW_BER,
                SHOW_EYE,
                SHOW_FEC,
                SHOW_SLTP,
                SHOW_SLRP,
                SHOW_MODULE,
                SHOW_DEVICE,
                SHOW_BER_MONITOR,
                SHOW_EXTERNAL_PHY,
                SHOW_LINK_DOWN_BLAME,
                SEND_BER_COLLECT,
                SEND_PAOS,
                SEND_PTYS,
                SEND_PPLM,
                SEND_PPLR,
                SEND_PRBS,
                SEND_SLTP,
                SEND_CLEAR_COUNTERS,
                SEND_PEPC,
                // Any new function's index should be added before SHOW_SEND_LAST in this enum
                FUNCTION_LAST
        };
    
    The vector should have been initialized like this:
    
        for (u_int32_t it = SHOW_PDDR; it < FUNCTION_LAST; it++) {
                _sendRegFuncMap.push_back(0);
        }
    
    Signed-off-by: Mark Haywood <mark.haywood@oracle.com>